### PR TITLE
Creating modifiable setting to change the speed at which robots get put into the chest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 .idea/httpRequests
+*.zip

--- a/README.MD
+++ b/README.MD
@@ -1,2 +1,2 @@
 # Purpose
-This is a fork of the "Bot Recaller" mod meant to add configurable speed option for how fast the bots are recalled.
+This is a fork of the "Bot Recaller" mod meant to add a configurable option to control how fast the bots are recalled.

--- a/README.MD
+++ b/README.MD
@@ -1,17 +1,2 @@
-*Bot Reacaller*
-
-Original mod was made by [cpeosphoros](https://forums.factorio.com/memberlist.php?mode=viewprofile&u=33391) and can be found [here](https://mods.factorio.com/mods/cpeosphoros/CpeBotRecaller)
-
-All i did was updating the config. :) i Even copied the Readme.
-
-Bots are collect from roboports to the Robot Recaller Chest. Good for upgrading bots.
-
-Should work with all modded bots and roboports, as long as their modder didn't change the internal name of those entities.
-
-Just build a Robot Recaller Chest and set one of its request slots to any kind of logistic bot.
-
-It will pull 1 bot of that kind per second from roboports in the same logistic network into the chest.
-
-If you set more than one kind to be requested, it will only pull the second kind if none of the first is available in the network.
-
-Both limits were set with balancing in mind. If you want a higher output, or to pull more than one kind at a time, just build more chests.
+# Purpose
+This is a fork of the "Bot Recaller" mod meant to add configurable speed option for how fast the bots are recalled.

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,8 @@
+@echo off
+rmdir /s /q "BotRecaller_0.17.3"
+del /s /q "BotRecaller*.zip"
+mkdir "BotRecaller_0.17.3"
+robocopy /s /e . BotRecaller_0.17.3 /mt /xd "BotRecaller_0.17.3" ".git" ".idea" /xf ".gitignore" "build.sh" "build.bat"
+7z a BotRecaller_0.17.3.zip "BotRecaller_0.17.3"
+rmdir /s /q "BotRecaller_0.17.3"
+pause

--- a/control.lua
+++ b/control.lua
@@ -1,5 +1,3 @@
-require "config"
-
 function checkRecallers()
 	local recallers = {}
 	for i, force in pairs(game.forces) do 
@@ -83,7 +81,7 @@ end
 
 
 script.on_event(defines.events.on_tick, function(event)
-	if event.tick % (seconds * 60) == 0 then
+	if event.tick % (settings.data.default_value * 60) == 0 then
 		checkRecallers()
 	end
 end)

--- a/control.lua
+++ b/control.lua
@@ -81,7 +81,7 @@ end
 
 
 script.on_event(defines.events.on_tick, function(event)
-	if event.tick % (settings.data.default_value * 60) == 0 then
+	if event.tick % (settings.startup["recall-delay-per-robot"].value * 60) == 0 then
 		checkRecallers()
 	end
 end)

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -1,2 +1,8 @@
 [entity-name]
 logistic-chest-botRecaller=Robot Recaller Chest
+
+[mod-setting-name]
+recall-delay-per-robot=Recall delay per robot
+
+[mod-setting-description]
+recall-delay-per-robot=Must result in a whole number when multiplied by 60

--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,8 @@
+data:extend({
+    {
+        type = "double-setting",
+        name = "recall-delay-per-robot",
+        setting_type = "startup",
+        default_value = 0.5
+    }
+})


### PR DESCRIPTION
Sorry for long title, couldn't figure out how to concisely say what I wanted to say in less words.
What I propose with this pull request is that there should be a setting under mod settings (startup tab) that would allow the user of this mod to edit the speed (by lowering the delay value) at which robots will get taken out of the logistic network and put into the robot recaller chest.

I have added a description to the settings section to specify that the value entered must always be a whole number (integer) when multiplied by 60: this is because it will break if it is not, I am unsure what causes this but it has something to do with how the original code is created (see control.lua:84).